### PR TITLE
Remove presumably unused cruft

### DIFF
--- a/plugin/hashrocket.vim
+++ b/plugin/hashrocket.vim
@@ -208,8 +208,4 @@ augroup hashrocket
 
   autocmd FileType ruby nmap <buffer> <leader>bt <Plug>BlockToggle
   autocmd BufRead *_spec.rb map <buffer> <leader>l <Plug>ExtractRspecLet
-
-  autocmd User Rails nnoremap <buffer> <D-r> :<C-U>Rake<CR>
-  autocmd User Rails nnoremap <buffer> <D-R> :<C-U>.Rake<CR>
-  autocmd User Fugitive command! -bang -bar -buffer -nargs=* Gpr :Git<bang> pull --rebase <args>
 augroup END


### PR DESCRIPTION
I added these an eternity ago and I doubt they have ever been used by anyone but me. If they are still desired, I'd highly recommend replacing them with more powerful equivalents: 

``` viml
  nnoremap <D-r> :Dispatch<CR>
  nnoremap <D-R> :<C-U>.Dispatch<CR>
  autocmd User Fugitive command! -bang -bar -buffer -nargs=* Gpr Gpull<bang> --rebase <args>
```
