### PR TITLE
Enable quick-quit from help files

### DIFF
--- a/plugin/hashrocket.vim
+++ b/plugin/hashrocket.vim
@@ -220,6 +220,7 @@ augroup hashrocket
 
   autocmd Syntax   css  syn sync minlines=50
 
+  autocmd FileType help nnoremap q :q<cr>
   autocmd FileType ruby nmap <buffer> <leader>bt <Plug>BlockToggle
   autocmd BufRead *_spec.rb map <buffer> <leader>l <Plug>ExtractRspecLet
   autocmd FileType sql nmap <buffer> <leader>t :<C-U>w \| call Send_to_Tmux("\\i ".expand("%")."\n")<CR>


### PR DESCRIPTION
Many plugins that open temporary splits or tabs allow you to simply hit
`q` from normal mode to exit from that split or tab. This commit adds
that functionality to the built-in Vim help files. Trust me, you'll love
it.