### PR TITLE
Remove Prettier/NeoFormat config from plugin

### DIFF
--- a/plugin/hashrocket.vim
+++ b/plugin/hashrocket.vim
@@ -225,13 +225,3 @@ augroup hashrocket
   autocmd BufRead *_spec.rb map <buffer> <leader>l <Plug>ExtractRspecLet
   autocmd FileType sql nmap <buffer> <leader>t :<C-U>w \| call Send_to_Tmux("\\i ".expand("%")."\n")<CR>
 augroup END
-
-if executable('prettier') && exists(':Neoformat')
-  let g:neoformat_try_formatprg = 1
-
-  augroup PrettierJSAutoFormat
-    autocmd!
-    autocmd FileType javascript,javascript.jsx setlocal formatprg=prettier\ --stdin\ --stdin-filepath=%
-    autocmd BufWritePre *.js,*.jsx Neoformat
-  augroup END
-endif


### PR DESCRIPTION
This configuration was outdated. It now lives closer to where the
NeoFormat plugin is defined: in dotmatrix's .vimrc

Also auto-formatting on save is no longer forced - but a commented code
you can copy and opt into.

[Please see PR #74 on dotmatrix](https://github.com/hashrocket/dotmatrix/pull/74)